### PR TITLE
Update src/blam.py

### DIFF
--- a/src/blam.py
+++ b/src/blam.py
@@ -1884,8 +1884,6 @@ class CameraCalibrationOperator(bpy.types.Operator):
         
 
 def initSceneProps():
-    scn = bpy.context.scene
-    
     '''
     Focal length and orientation estimation stuff
     '''


### PR DESCRIPTION
The context is now restricted on addon load, accessing the scene was don't but then never used, so simple one line correction.

See this thread:
http://markmail.org/message/5zu3bi2pnjuexyas

And this report:
http://projects.blender.org/tracker/index.php?func=detail&aid=33645&group_id=9&atid=498
